### PR TITLE
feat: extend instrumented-aws-clients rule to support more cases

### DIFF
--- a/lib/rules/instrument-aws-clients.js
+++ b/lib/rules/instrument-aws-clients.js
@@ -16,6 +16,10 @@ module.exports = {
       category: "Tracing",
       recommended: true,
     },
+    messages: {
+      clientNotInstrumented: "AWS client not instrumented: {{client}}",
+    },
+
     fixable: null, // or "code" or "whitespace"
     schema: [
       // fill in your schema
@@ -24,31 +28,71 @@ module.exports = {
 
   create: function (context) {
     const code = context.getSourceCode()
-    var awsVars
-    var safe = false
+    var awsClients
+    var awsClientInstances
+
+    /**
+     * Reports an AST node as a rule violation.
+     * @param {ASTNode} node The node to report.
+     * @param {ASTNode|undefined} data The service client instance to report, defaults to `node`
+     * @returns {void}
+     */
+    function report(node, data) {
+      data = data || node
+      context.report({
+        node,
+        messageId: "clientNotInstrumented",
+        data: { client: code.getText(data) },
+      })
+    }
+
+    /**
+     * Returns a variable for the current scope if exists.
+     * @param {string} name The node to report.
+     * @returns {Variable|undefined}
+     */
+    function varInScope(name) {
+      return context.getScope().set.get(name)
+    }
 
     return {
       Program: () => {
-        awsVars = []
+        awsClients = new Set()
+        awsClientInstances = new Map()
       },
+
       ImportDeclaration: (node) => {
         if (node.source.value.startsWith("aws-sdk/clients/")) {
-          awsVars.push(node.specifiers[0].local.name)
+          node.specifiers.map((o) => awsClients.add(o.local.name))
         }
       },
-      "CallExpression[callee.property.name='captureAWSClient'][arguments.length=1]": () => {
-        safe = true
+
+      "VariableDeclarator:has(NewExpression)": (node) => {
+        const name = node.init.callee.name
+        if (name && awsClients.has(name)) {
+          const scopeVar = varInScope(node.id.name)
+          awsClientInstances.set(scopeVar, node)
+        }
       },
-      "CallExpression[callee.property.name='captureAWSClient'][arguments.length=1]:exit": () => {
-        safe = false
+
+      "Program:exit": () => {
+        awsClientInstances.forEach((node) => report(node))
       },
-      "NewExpression:has(Identifier)": (node) => {
-        const name = node.callee.name
-        if (name && awsVars.includes(name) && !safe) {
-          context.report({
-            node,
-            message: `AWS client not instrumented: ${code.getText(node)}`,
-          })
+
+      CallExpression: (node) => {
+        const scopeVar = varInScope(node.callee.object.name)
+        if (scopeVar && awsClientInstances.has(scopeVar)) {
+          report(node, awsClientInstances.get(scopeVar))
+          awsClientInstances.delete(scopeVar)
+        }
+      },
+
+      "CallExpression[callee.property.name='captureAWSClient'][arguments.length=1][arguments.0.type=Identifier]": (
+        node,
+      ) => {
+        const scopeVar = varInScope(node.arguments[0].name)
+        if (scopeVar && awsClientInstances.has(scopeVar)) {
+          awsClientInstances.delete(scopeVar)
         }
       },
     }

--- a/lib/rules/instrument-aws-clients.js
+++ b/lib/rules/instrument-aws-clients.js
@@ -28,8 +28,8 @@ module.exports = {
 
   create: function (context) {
     const code = context.getSourceCode()
-    var awsClients
-    var awsClientInstances
+    let awsClients
+    let awsClientInstances
 
     /**
      * Reports an AST node as a rule violation.

--- a/tests/lib/rules/instrument-aws-clients.js
+++ b/tests/lib/rules/instrument-aws-clients.js
@@ -15,11 +15,55 @@ var rule = require("../../../lib/rules/instrument-aws-clients"),
 // Tests
 //------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester()
+var ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: "module",
+  },
+})
+
 ruleTester.run("instrument-aws-clients", rule, {
   valid: [
-    // give me some code that won't trigger a warning
+    "import SecretsManager from 'aws-sdk/clients/secretsmanager'\n" +
+      "const ssm = new SecretsManager()\n" +
+      "AWSXRay.captureAWSClient(ssm)",
+
+    "import { SecretsManager, DynamoDB } from 'aws-sdk/clients/secretsmanager'\n" +
+      "let ddb = new DynamoDB()\n" +
+      "AWSXRay.captureAWSClient(ddb)\n" +
+      "AWSXRay.captureAWSClient(new SecretsManager())",
   ],
 
-  invalid: [],
+  invalid: [
+    {
+      code:
+        "import SecretsManager from 'aws-sdk/clients/secretsmanager'\n" +
+        "var ssm = new SecretsManager()\n" +
+        "function test() {\n" +
+        "  const ssm = new SecretsManager()\n" +
+        "  AWSXRay.captureAWSClient(ssm)\n" +
+        "}\n" +
+        "ssm.cancelRotateSecret()",
+      errors: [
+        {
+          messageId: "clientNotInstrumented",
+          data: { client: "ssm = new SecretsManager()" },
+        },
+      ],
+    },
+
+    {
+      code:
+        "import SecretsManager from 'aws-sdk/clients/secretsmanager'\n" +
+        "const ssm = new SecretsManager()\n" +
+        "ssm.cancelRotateSecret()\n" +
+        "AWSXRay.captureAWSClient(ssm)",
+      errors: [
+        {
+          messageId: "clientNotInstrumented",
+          data: { client: "ssm = new SecretsManager()" },
+        },
+      ],
+    },
+  ],
 })


### PR DESCRIPTION
- extending the "instrumented-aws-clients" rule to support more cases (multiple client imports with a single statement, instantiating outside `captureAWSClient` call, shadowed vars)
- adding tests for the "instrumented-aws-clients" rule 
