### PR TITLE
feat: extend instrumented-document-clients rule, add tests

### DIFF
--- a/docs/rules/instrument-document-clients.md
+++ b/docs/rules/instrument-document-clients.md
@@ -20,7 +20,7 @@ Examples of **correct** code for this rule:
 import DynamoDB from "aws-sdk/clients/dynamodb"
 
 const dynamoClient = new DynamoDB.DocumentClient()
-AWSXRay.captureAWSClient((dynamoClient as any).service);
+AWSXRay.captureAWSClient(dynamoClient.service)
 ```
 
 ## When Not To Use It

--- a/lib/rules/instrument-document-clients.js
+++ b/lib/rules/instrument-document-clients.js
@@ -17,6 +17,11 @@ module.exports = {
       category: "Tracing",
       recommended: true,
     },
+    messages: {
+      notInstrumented: "Called {{name}} before it was instrumented.",
+      instrumentService:
+        "DocumentClient should be instrumented using `service` property.",
+    },
     fixable: null, // or "code" or "whitespace"
     schema: [
       // fill in your schema
@@ -24,42 +29,86 @@ module.exports = {
   },
 
   create: function (context) {
-    var trackedVariables = []
-    function varInScope(x) {
-      return context.getScope().set.get(x)
+    let trackedVariables = new Set()
+
+    /**
+     * Returns a variable for the current scope if exists.
+     * @param {string} name The node to report.
+     * @returns {Variable|undefined}
+     */
+    function varInScope(name) {
+      return context.getScope().set.get(name)
     }
+
+    /**
+     * Checks whether a variable is being tracked
+     * @param {string} name Variable name
+     * @returns {Boolean}
+     */
+    function isTracked(name) {
+      return trackedVariables.has(varInScope(name))
+    }
+
+    function reportInstrumentService(node) {
+      context.report({
+        node,
+        messageId: "instrumentService",
+      })
+    }
+
+    function checkMemberExpression(node) {
+      const noProperty = !node.property
+      const wrongProperty = node.property && node.property.name !== "service"
+
+      if (noProperty || wrongProperty) {
+        reportInstrumentService(node)
+      }
+    }
+
+    function checkIdentifier(node) {
+      if (node.name) {
+        reportInstrumentService(node)
+      }
+    }
+
     return {
-      "NewExpression[callee.property.name = 'DocumentClient']": (node) => {
-        const parent = context.getAncestors().reverse()[0]
-        if (parent.type !== "VariableDeclarator") {
-          context.report({
-            node,
-            message:
-              "DocumentClient should be instantiated and instrumented before being used",
-          })
-        }
-      },
-      "VariableDeclarator:has(NewExpression[callee.property.name='DocumentClient'])": (
+      "VariableDeclarator > NewExpression[callee.property.name='DocumentClient']": (
         node,
       ) => {
-        if (node.id.name) {
-          trackedVariables.push(varInScope(node.id.name))
+        if (node.parent.id && node.parent.id.name) {
+          trackedVariables.add(varInScope(node.parent.id.name))
         }
       },
-      "CallExpression[callee.property.name='captureAWSClient'][arguments.length=1] MemberExpression.arguments *.object Identifier[name]": (
+
+      "CallExpression[callee.property.name='captureAWSClient']:has(NewExpression[callee.property.name='DocumentClient']) .arguments": (
         node,
       ) => {
-        const instrumented = varInScope(node.name)
-        trackedVariables = trackedVariables.filter((v) => v !== instrumented)
+        checkMemberExpression(node)
       },
+
+      "CallExpression[callee.property.name='captureAWSClient'][arguments.length=1] .arguments[type!='NewExpression']": (
+        node,
+      ) => {
+        const name = node.name || node.object.name
+        if (!isTracked(name)) return
+
+        switch (node.type) {
+          case "MemberExpression":
+            return checkMemberExpression(node)
+          case "Identifier":
+            return checkIdentifier(node)
+        }
+      },
+
       "CallExpression[callee.object.name]": (node) => {
-        const v = varInScope(node.callee.object.name)
-        if (trackedVariables.includes(v)) {
-          context.report({
-            node,
-            message: `Called ${v.name} before it was instrumented`,
-          })
-        }
+        const name = node.callee.object.name
+        if (!isTracked(name)) return
+
+        context.report({
+          node,
+          messageId: "notInstrumented",
+          data: { name: name },
+        })
       },
     }
   },


### PR DESCRIPTION
- extending the rule: 
  - checking if `DocumentClient` is instrumented using `service` property
  - support for instrumentation of inline instantiation `DocumentClient` e.g. `...captureAWSClient(new DynamoDB.DocumentClient())`
- adding test coverage
