### PR TITLE
fix: undefined case in instrument-aws-clients rule

### DIFF
--- a/lib/rules/instrument-aws-clients.js
+++ b/lib/rules/instrument-aws-clients.js
@@ -79,7 +79,7 @@ module.exports = {
         awsClientInstances.forEach((node) => report(node))
       },
 
-      CallExpression: (node) => {
+      "CallExpression[callee.object]": (node) => {
         const scopeVar = varInScope(node.callee.object.name)
         if (scopeVar && awsClientInstances.has(scopeVar)) {
           report(node, awsClientInstances.get(scopeVar))


### PR DESCRIPTION
Fixes issues with undefined `callee.object` expressions.