### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Stedi/cloud


### PR DESCRIPTION
I believe Cloud/SaaS Core is the only user of this package: https://cs.github.com/?scope=org%3AStedi&scopeName=Stedi&q=eslint-plugin-stedi-aws-rules